### PR TITLE
feat(ModGen): add `data/tiles` and `data/definitions` subfolders

### DIFF
--- a/ModGen.py
+++ b/ModGen.py
@@ -6,7 +6,7 @@ def GenerateModFolder(output_path, name, description, author="Unknown"):
     mod_folder_path = os.path.join(output_path, name)
     os.makedirs(mod_folder_path, exist_ok=True)
     
-    subfolders = ["audio", "data", "graphics", "meshes"]
+    subfolders = ["audio", "data", "data/tiles", "data/definitions", "graphics", "meshes"]
     for subfolder in subfolders:
         os.makedirs(os.path.join(mod_folder_path, subfolder), exist_ok=True)
     


### PR DESCRIPTION
This PR simply makes the mod gen generate `data/tiles` and `data/definitions` directories for any generated mods.

These directories are used by the game for modifying existing tiles and modifying/creating vehicle components.